### PR TITLE
Updated elgohr/Github-Release-Action to a supported version (v4)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
         
     - uses: actions/checkout@master
     - name: Create a Release
-      uses: elgohr/Github-Release-Action@master
+      uses: elgohr/Github-Release-Action@v4
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:


### PR DESCRIPTION
elgohr/Github-Release-Action@master is not supported anymore